### PR TITLE
Minor bug fixes for SimCLR loss and ViT-S hyperparameter

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -46,7 +46,7 @@ class ACLIPLoss(nn.Module):
         image_ssl_embed = outputs["image_ssl_embed"]
         inputs = {}
         inputs["aug1_embed"] = image_ssl_embed[:bs]
-        inputs["aug2_embed"] = image_ssl_embed[:bs]
+        inputs["aug2_embed"] = image_ssl_embed[bs:]
         simclr_loss_dict = self.simclr_loss(inputs)
 
         def loss_fn(x, y):

--- a/models.py
+++ b/models.py
@@ -763,7 +763,7 @@ def ACLIP_VITS16(mask_ratio=0, **kwargs):
         "mask_vit_small_patch16_224", num_classes=0, mask_ratio=mask_ratio
     )
     vision_model_ema = timm.create_model(
-        "mask_vit_small_patch16_224", num_classes=0, mask_ratio=mask_ratio
+        "mask_vit_small_patch16_224", num_classes=0, mask_ratio=0
     )
     model = ACLIP(
         embed_dim=512,


### PR DESCRIPTION
1. Fixed SimCLR loss calculation in `losses.py`. I believe the current code does not compare the two different augmentations.
2. ViT-S EMA mask ratio was previously set to `mask_ratio` from the user. I think this should be default to 0 like other ViT sizes.